### PR TITLE
fix: adding buildArgs and buildSecrets environment from dokploy 0.28

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2574,6 +2574,8 @@ func (c *DokployClient) UpdateApplicationEnv(appID string, updateFn func(envMap 
 		payload := map[string]interface{}{
 			"applicationId": appID,
 			"env":           newEnvStr,
+			"buildArgs":     "",
+			"buildSecrets":  "",
 		}
 		if createEnvFile != nil {
 			payload["createEnvFile"] = *createEnvFile


### PR DESCRIPTION
## Related Issue

Fixes #40

## Description

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of 
another solution.

> Add an empty value for missing `buildArgs` and `buildSecrets` when updating an environment to not run into a `BAD_REQUEST`
> Since there isn't any handling of these arguments anywhere else, I've only added an empty value to reflect what is done from `dokploy` when saving an environment from their UI

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No change in security, only adding missing fields
