### PR TITLE
fix(compose): stabilize sensitive env updates and teardown endpoint

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1923,7 +1923,7 @@ func (c *DokployClient) DeleteCompose(id string) error {
 	payload := map[string]string{
 		"composeId": id,
 	}
-	_, err := c.doRequest("POST", "compose.remove", payload)
+	_, err := c.doRequest("POST", "compose.delete", payload)
 	return err
 }
 

--- a/internal/provider/data_source_compose.go
+++ b/internal/provider/data_source_compose.go
@@ -264,16 +264,17 @@ func (d *ComposeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 				Description: "Build path within the Gitea repository.",
 			},
 
-			// Environment
-			"env": schema.StringAttribute{
-				Computed:    true,
-				Description: "Environment variables in KEY=VALUE format.",
-			},
-
 			// Runtime configuration
 			"auto_deploy": schema.BoolAttribute{
 				Computed:    true,
 				Description: "Whether auto-deploy is enabled.",
+			},
+
+			// Environment
+			"env": schema.StringAttribute{
+				Computed:    true,
+				Sensitive:   true,
+				Description: "Environment variables in KEY=VALUE format.",
 			},
 
 			// Advanced configuration
@@ -454,6 +455,7 @@ func (d *ComposeDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	if comp.GiteaBuildPath != "" {
 		data.GiteaBuildPath = types.StringValue(comp.GiteaBuildPath)
 	}
+	// Environment - read from API (data source, may return masked values)
 	if comp.Env != "" {
 		data.Env = types.StringValue(comp.Env)
 	}

--- a/internal/provider/resource_compose.go
+++ b/internal/provider/resource_compose.go
@@ -330,7 +330,11 @@ func (r *ComposeResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 
 			// Environment
 			"env": schema.StringAttribute{
-				Optional:    true,
+				Optional:  true,
+				Sensitive: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Description: "Environment variables in KEY=VALUE format, one per line.",
 			},
 
@@ -446,6 +450,7 @@ func (r *ComposeResource) Create(ctx context.Context, req resource.CreateRequest
 		Name:              plan.Name.ValueString(),
 		EnvironmentID:     plan.EnvironmentID.ValueString(),
 		ComposeFile:       plan.ComposeFileContent.ValueString(),
+		Env:               plan.Env.ValueString(),
 		SourceType:        plan.SourceType.ValueString(),
 		CustomGitUrl:      plan.CustomGitUrl.ValueString(),
 		CustomGitBranch:   plan.CustomGitBranch.ValueString(),
@@ -542,6 +547,7 @@ func (r *ComposeResource) Create(ctx context.Context, req resource.CreateRequest
 
 	// Update plan from created compose
 	plan.ID = types.StringValue(createdComp.ID)
+
 	readComposeIntoState(ctx, &plan, createdComp, &resp.Diagnostics)
 
 	if !plan.DeployOnCreate.IsNull() && plan.DeployOnCreate.ValueBool() {
@@ -594,6 +600,13 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	// Preserve existing env value when plan value is unknown.
+	// This can happen with sensitive values during apply.
+	effectiveEnv := plan.Env
+	if plan.Env.IsUnknown() {
+		effectiveEnv = state.Env
+	}
+
 	environmentChanged := !plan.EnvironmentID.Equal(state.EnvironmentID)
 
 	// Check if environment_id changed - use compose.move API
@@ -607,6 +620,7 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 		// Check if only environment_id changed - if so, skip the update call
 		onlyEnvironmentChanged := plan.Name.Equal(state.Name) &&
 			plan.ComposeFileContent.Equal(state.ComposeFileContent) &&
+			plan.Env.Equal(state.Env) &&
 			plan.SourceType.Equal(state.SourceType) &&
 			plan.CustomGitUrl.Equal(state.CustomGitUrl) &&
 			plan.CustomGitBranch.Equal(state.CustomGitBranch) &&
@@ -624,6 +638,7 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 		if onlyEnvironmentChanged {
 			// MoveCompose is sufficient; use returned data to update state
 			readComposeIntoState(ctx, &plan, movedComp, &resp.Diagnostics)
+			plan.Env = effectiveEnv
 			diags = resp.State.Set(ctx, plan)
 			resp.Diagnostics.Append(diags...)
 			return
@@ -645,6 +660,7 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 		Name:              plan.Name.ValueString(),
 		EnvironmentID:     plan.EnvironmentID.ValueString(),
 		ComposeFile:       plan.ComposeFileContent.ValueString(),
+		Env:               effectiveEnv.ValueString(),
 		SourceType:        plan.SourceType.ValueString(),
 		CustomGitUrl:      plan.CustomGitUrl.ValueString(),
 		CustomGitBranch:   plan.CustomGitBranch.ValueString(),
@@ -730,6 +746,7 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	readComposeIntoState(ctx, &plan, updatedComp, &resp.Diagnostics)
+	plan.Env = effectiveEnv
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -911,10 +928,9 @@ func readComposeIntoState(ctx context.Context, state *ComposeResourceModel, comp
 		state.GiteaBuildPath = types.StringValue(comp.GiteaBuildPath)
 	}
 
-	// Environment
-	if comp.Env != "" {
-		state.Env = types.StringValue(comp.Env)
-	}
+	// Environment - Do NOT read from API
+	// The compose.one endpoint returns masked values for env
+	// We keep the plan value in state instead (which is correct since env is marked as sensitive)
 
 	// Runtime
 	state.AutoDeploy = types.BoolValue(comp.AutoDeploy)

--- a/internal/provider/resource_compose_test.go
+++ b/internal/provider/resource_compose_test.go
@@ -277,3 +277,158 @@ EOF
 }
 `, os.Getenv("DOKPLOY_HOST"), os.Getenv("DOKPLOY_API_KEY"), projectName, envName, composeName, description, composeContent, env)
 }
+
+// TestAccComposeResourceEnvVariables tests compose with environment variables.
+// This test specifically covers the bug fix for the "inconsistent result after apply" error
+// when env variables are specified.
+func TestAccComposeResourceEnvVariables(t *testing.T) {
+	host := os.Getenv("DOKPLOY_HOST")
+	apiKey := os.Getenv("DOKPLOY_API_KEY")
+
+	if host == "" || apiKey == "" {
+		t.Skip("DOKPLOY_HOST and DOKPLOY_API_KEY must be set for acceptance tests")
+	}
+
+	// Test with multiple environment variables including one with special characters
+	envVars := `DATABASE_URL=postgres://user:pass@host:5432/db
+API_KEY=secret-key-123
+DEBUG=true
+MULTILINE=value with spaces`
+	envVarsWithTrailingNewline := envVars + "\n"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with environment variables
+			{
+				Config: testAccComposeResourceEnvConfig("test-env-vars-project", "test-env-vars-env", "test-env-vars", envVars),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dokploy_compose.test", "name", "test-env-vars"),
+					resource.TestCheckResourceAttr("dokploy_compose.test", "env", envVarsWithTrailingNewline),
+					resource.TestCheckResourceAttrSet("dokploy_compose.test", "id"),
+				),
+			},
+			// Update with different environment variables - this is the key test for the bug fix
+			{
+				Config: testAccComposeResourceEnvConfig("test-env-vars-project", "test-env-vars-env", "test-env-vars", "UPDATED_VAR=updated-value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dokploy_compose.test", "env", "UPDATED_VAR=updated-value\n"),
+				),
+			},
+			// ImportState test - env is sensitive so we need to ignore it
+			{
+				ResourceName:            "dokploy_compose.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deploy_on_create", "branch", "trigger_type", "env"},
+			},
+		},
+	})
+}
+
+func testAccComposeResourceEnvConfig(projectName, envName, composeName, env string) string {
+	return fmt.Sprintf(`
+provider "dokploy" {
+  host    = "%s"
+  api_key = "%s"
+}
+
+resource "dokploy_project" "test" {
+  name        = "%s"
+  description = "Test project for compose env variables tests"
+}
+
+resource "dokploy_environment" "test" {
+  project_id = dokploy_project.test.id
+  name       = "%s"
+}
+
+resource "dokploy_compose" "test" {
+  environment_id = dokploy_environment.test.id
+  name           = "%s"
+  source_type    = "raw"
+  compose_file_content = <<EOF
+version: '3.8'
+services:
+  web:
+    image: nginx:latest
+EOF
+  env = <<EOF
+%s
+EOF
+}
+`, os.Getenv("DOKPLOY_HOST"), os.Getenv("DOKPLOY_API_KEY"), projectName, envName, composeName, env)
+}
+
+// TestAccComposeResourceEnvWithSensitiveData tests that sensitive env values
+// (like passwords and keys) are properly handled without causing
+// "inconsistent result after apply" errors.
+func TestAccComposeResourceEnvWithSensitiveData(t *testing.T) {
+	host := os.Getenv("DOKPLOY_HOST")
+	apiKey := os.Getenv("DOKPLOY_API_KEY")
+
+	if host == "" || apiKey == "" {
+		t.Skip("DOKPLOY_HOST and DOKPLOY_API_KEY must be set for acceptance tests")
+	}
+
+	// Simulate sensitive data that should be marked as sensitive
+	sensitiveEnv := `DB_PASSWORD=P@ssw0rd!#$%
+JWT_SECRET=super-secret-jwt-token-key-12345
+AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY`
+	sensitiveEnvWithTrailingNewline := sensitiveEnv + "\n"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with sensitive environment variables
+			{
+				Config: testAccComposeResourceEnvConfig("test-sensitive-env-project", "test-sensitive-env", "test-sensitive-compose", sensitiveEnv),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dokploy_compose.test", "name", "test-sensitive-compose"),
+					resource.TestCheckResourceAttr("dokploy_compose.test", "env", sensitiveEnvWithTrailingNewline),
+				),
+			},
+			// Update sensitive env - this specifically tests the bug fix
+			{
+				Config: testAccComposeResourceEnvConfig("test-sensitive-env-project", "test-sensitive-env", "test-sensitive-compose", "DB_PASSWORD=NewP@ssw0rd!"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dokploy_compose.test", "env", "DB_PASSWORD=NewP@ssw0rd!\n"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccComposeResourceEnvClear tests clearing env by setting to empty string.
+// This specifically verifies the transition from non-empty to empty env works.
+func TestAccComposeResourceEnvClear(t *testing.T) {
+	host := os.Getenv("DOKPLOY_HOST")
+	apiKey := os.Getenv("DOKPLOY_API_KEY")
+
+	if host == "" || apiKey == "" {
+		t.Skip("DOKPLOY_HOST and DOKPLOY_API_KEY must be set for acceptance tests")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with env
+			{
+				Config: testAccComposeResourceEnvConfig("test-env-clear-project", "test-env-clear-env", "test-env-clear-compose", "KEY=value"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dokploy_compose.test", "env", "KEY=value\n"),
+				),
+			},
+			// Step 2: Clear env by setting to empty
+			{
+				Config: testAccComposeResourceEnvConfig("test-env-clear-project", "test-env-clear-env", "test-env-clear-compose", ""),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dokploy_compose.test", "env", "\n"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary
- Fixes `dokploy_compose.env` apply inconsistency by treating `env` as sensitive state and preserving state when planned value is unknown.
- Sends `env` in compose create/update requests and stops rehydrating `env` from API responses that can return masked values.
- Fixes compose deletion endpoint from `compose.remove` to `compose.delete` to match Dokploy API behavior.
- Adds acceptance coverage for compose env update flows and sensitive env values.

## Why
Users hit `Provider produced inconsistent result after apply` for `dokploy_compose.env` during in-place updates. The API can mask env values on read, causing post-apply state mismatch. This change aligns provider state behavior with sensitive semantics and observed API behavior.

## Validation
- `go test ./...`
- `fnox exec -- env TF_ACC=1 go test -v ./internal/provider -run 'TestAccComposeResourceEnvVariables|TestAccComposeResourceEnvWithSensitiveData' -count=1`
- Manual OpenTofu apply against real stack now completes successfully for env-only compose updates.