### PR TITLE
fix(backup): add metadata nested block for compose postgres backups

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3592,22 +3592,23 @@ func (c *DokployClient) ListDestinations() ([]Destination, error) {
 
 // Backup represents a scheduled backup configuration.
 type Backup struct {
-	BackupID        string `json:"backupId"`
-	AppName         string `json:"appName"`
-	Schedule        string `json:"schedule"`
-	Enabled         bool   `json:"enabled"`
-	Database        string `json:"database"`
-	Prefix          string `json:"prefix"`
-	DestinationID   string `json:"destinationId"`
-	KeepLatestCount int    `json:"keepLatestCount"`
-	BackupType      string `json:"backupType"`   // "database" or "compose"
-	DatabaseType    string `json:"databaseType"` // "postgres", "mysql", "mariadb", "mongo"
-	PostgresID      string `json:"postgresId"`
-	MysqlID         string `json:"mysqlId"`
-	MariadbID       string `json:"mariadbId"`
-	MongoID         string `json:"mongoId"`
-	ComposeID       string `json:"composeId"`
-	ServiceName     string `json:"serviceName"`
+	BackupID        string                 `json:"backupId"`
+	AppName         string                 `json:"appName"`
+	Schedule        string                 `json:"schedule"`
+	Enabled         bool                   `json:"enabled"`
+	Database        string                 `json:"database"`
+	Prefix          string                 `json:"prefix"`
+	DestinationID   string                 `json:"destinationId"`
+	KeepLatestCount int                    `json:"keepLatestCount"`
+	BackupType      string                 `json:"backupType"`   // "database" or "compose"
+	DatabaseType    string                 `json:"databaseType"` // "postgres", "mysql", "mariadb", "mongo"
+	PostgresID      string                 `json:"postgresId"`
+	MysqlID         string                 `json:"mysqlId"`
+	MariadbID       string                 `json:"mariadbId"`
+	MongoID         string                 `json:"mongoId"`
+	ComposeID       string                 `json:"composeId"`
+	ServiceName     string                 `json:"serviceName"`
+	Metadata        map[string]interface{} `json:"metadata"`
 }
 
 func (c *DokployClient) CreateBackup(backup Backup) (*Backup, error) {
@@ -3619,6 +3620,9 @@ func (c *DokployClient) CreateBackup(backup Backup) (*Backup, error) {
 		"database":      backup.Database,
 		"backupType":    backup.BackupType,
 		"databaseType":  backup.DatabaseType,
+	}
+	if len(backup.Metadata) > 0 {
+		payload["metadata"] = backup.Metadata
 	}
 
 	if backup.KeepLatestCount > 0 {
@@ -3731,6 +3735,9 @@ func (c *DokployClient) UpdateBackup(backup Backup) (*Backup, error) {
 		"database":      backup.Database,
 		"databaseType":  backup.DatabaseType,
 		"serviceName":   backup.ServiceName,
+	}
+	if len(backup.Metadata) > 0 {
+		payload["metadata"] = backup.Metadata
 	}
 
 	if backup.KeepLatestCount > 0 {

--- a/internal/provider/resource_backup.go
+++ b/internal/provider/resource_backup.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/ahmedali6/terraform-provider-dokploy/internal/client"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -17,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
 
 var _ resource.Resource = &BackupResource{}
@@ -38,6 +41,7 @@ type BackupResourceModel struct {
 	DatabaseType    types.String `tfsdk:"database_type"`
 	ComposeID       types.String `tfsdk:"compose_id"`
 	ServiceName     types.String `tfsdk:"service_name"`
+	Metadata        types.Object `tfsdk:"metadata"`
 	Schedule        types.String `tfsdk:"schedule"`
 	Enabled         types.Bool   `tfsdk:"enabled"`
 	Prefix          types.String `tfsdk:"prefix"`
@@ -104,6 +108,21 @@ func (r *BackupResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Optional:    true,
 				Description: "Name of the service within the compose to backup. Required when backup_type is 'compose'.",
 			},
+			"metadata": schema.SingleNestedAttribute{
+				Optional:    true,
+				Description: "Backup metadata by database type. For postgres compose backups, set metadata.postgres.database_user.",
+				Attributes: map[string]schema.Attribute{
+					"postgres": schema.SingleNestedAttribute{
+						Optional: true,
+						Attributes: map[string]schema.Attribute{
+							"database_user": schema.StringAttribute{
+								Optional:    true,
+								Description: "Postgres database user for backup metadata.",
+							},
+						},
+					},
+				},
+			},
 			"schedule": schema.StringAttribute{
 				Required:    true,
 				Description: "Cron schedule for backups (e.g., '0 2 * * *' for daily at 2 AM).",
@@ -157,6 +176,8 @@ func (r *BackupResource) Create(ctx context.Context, req resource.CreateRequest,
 		backupType = "database"
 	}
 
+	postgresUser := resolvePostgresDatabaseUser(plan)
+
 	// Validate required fields based on backup_type
 	switch backupType {
 	case "database":
@@ -175,6 +196,14 @@ func (r *BackupResource) Create(ctx context.Context, req resource.CreateRequest,
 		}
 		if plan.ServiceName.IsNull() || plan.ServiceName.ValueString() == "" {
 			resp.Diagnostics.AddError("Missing required field", "service_name is required when backup_type is 'compose'")
+			return
+		}
+		dbType := plan.DatabaseType.ValueString()
+		if dbType == "" {
+			dbType = "postgres"
+		}
+		if dbType == "postgres" && postgresUser == "" {
+			resp.Diagnostics.AddError("Missing required field", "metadata.postgres.database_user is required when backup_type is 'compose' and database_type is 'postgres'")
 			return
 		}
 	}
@@ -212,6 +241,13 @@ func (r *BackupResource) Create(ctx context.Context, req resource.CreateRequest,
 		} else {
 			backup.DatabaseType = "postgres"
 		}
+		if backup.DatabaseType == "postgres" {
+			backup.Metadata = map[string]interface{}{
+				"postgres": map[string]interface{}{
+					"databaseUser": postgresUser,
+				},
+			}
+		}
 	}
 
 	createdBackup, err := r.client.CreateBackup(backup)
@@ -230,6 +266,15 @@ func (r *BackupResource) Create(ctx context.Context, req resource.CreateRequest,
 
 	if createdBackup.ServiceName != "" {
 		plan.ServiceName = types.StringValue(createdBackup.ServiceName)
+	}
+	if createdBackup.Metadata != nil {
+		if postgresMeta, ok := createdBackup.Metadata["postgres"].(map[string]interface{}); ok {
+			if dbUser, ok := postgresMeta["databaseUser"].(string); ok && dbUser != "" {
+				metadataValue, metadataDiags := postgresMetadataObjectValue(dbUser)
+				resp.Diagnostics.Append(metadataDiags...)
+				plan.Metadata = metadataValue
+			}
+		}
 	}
 
 	diags = resp.State.Set(ctx, plan)
@@ -285,6 +330,15 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 		if backup.ServiceName != "" {
 			state.ServiceName = types.StringValue(backup.ServiceName)
 		}
+		if backup.Metadata != nil {
+			if postgresMeta, ok := backup.Metadata["postgres"].(map[string]interface{}); ok {
+				if dbUser, ok := postgresMeta["databaseUser"].(string); ok && dbUser != "" {
+					metadataValue, metadataDiags := postgresMetadataObjectValue(dbUser)
+					resp.Diagnostics.Append(metadataDiags...)
+					state.Metadata = metadataValue
+				}
+			}
+		}
 	}
 
 	diags = resp.State.Set(ctx, state)
@@ -326,6 +380,27 @@ func (r *BackupResource) Update(ctx context.Context, req resource.UpdateRequest,
 		backup.ServiceName = plan.ServiceName.ValueString()
 	}
 
+	postgresUser := resolvePostgresDatabaseUser(plan)
+
+	if backupType == "compose" && backup.DatabaseType == "postgres" {
+		if postgresUser == "" {
+			resp.Diagnostics.AddError("Missing required field", "metadata.postgres.database_user is required when backup_type is 'compose' and database_type is 'postgres'")
+			return
+		}
+	}
+
+	if backup.DatabaseType == "postgres" {
+		databaseUser := "postgres"
+		if backupType == "compose" {
+			databaseUser = postgresUser
+		}
+		backup.Metadata = map[string]interface{}{
+			"postgres": map[string]interface{}{
+				"databaseUser": databaseUser,
+			},
+		}
+	}
+
 	updatedBackup, err := r.client.UpdateBackup(backup)
 	if err != nil {
 		resp.Diagnostics.AddError("Error updating backup", err.Error())
@@ -340,6 +415,15 @@ func (r *BackupResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	if updatedBackup.ServiceName != "" {
 		plan.ServiceName = types.StringValue(updatedBackup.ServiceName)
+	}
+	if updatedBackup.Metadata != nil {
+		if postgresMeta, ok := updatedBackup.Metadata["postgres"].(map[string]interface{}); ok {
+			if dbUser, ok := postgresMeta["databaseUser"].(string); ok && dbUser != "" {
+				metadataValue, metadataDiags := postgresMetadataObjectValue(dbUser)
+				resp.Diagnostics.Append(metadataDiags...)
+				plan.Metadata = metadataValue
+			}
+		}
 	}
 
 	diags = resp.State.Set(ctx, plan)
@@ -366,4 +450,37 @@ func (r *BackupResource) Delete(ctx context.Context, req resource.DeleteRequest,
 
 func (r *BackupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func resolvePostgresDatabaseUser(plan BackupResourceModel) string {
+	if !plan.Metadata.IsNull() && !plan.Metadata.IsUnknown() {
+		if postgresAttr, exists := plan.Metadata.Attributes()["postgres"]; exists && !postgresAttr.IsNull() && !postgresAttr.IsUnknown() {
+			if postgresObj, ok := postgresAttr.(basetypes.ObjectValue); ok {
+				if dbUserAttr, exists := postgresObj.Attributes()["database_user"]; exists && !dbUserAttr.IsNull() && !dbUserAttr.IsUnknown() {
+					if dbUser, ok := dbUserAttr.(basetypes.StringValue); ok {
+						return dbUser.ValueString()
+					}
+				}
+			}
+		}
+	}
+
+	return ""
+}
+
+func postgresMetadataObjectValue(databaseUser string) (types.Object, diag.Diagnostics) {
+	postgresValue, diags := types.ObjectValue(
+		map[string]attr.Type{"database_user": types.StringType},
+		map[string]attr.Value{"database_user": types.StringValue(databaseUser)},
+	)
+	if diags.HasError() {
+		return types.ObjectNull(map[string]attr.Type{"postgres": types.ObjectType{AttrTypes: map[string]attr.Type{"database_user": types.StringType}}}), diags
+	}
+
+	metadataValue, metadataDiags := types.ObjectValue(
+		map[string]attr.Type{"postgres": types.ObjectType{AttrTypes: map[string]attr.Type{"database_user": types.StringType}}},
+		map[string]attr.Value{"postgres": postgresValue},
+	)
+	diags.Append(metadataDiags...)
+	return metadataValue, diags
 }

--- a/internal/provider/resource_backup_test.go
+++ b/internal/provider/resource_backup_test.go
@@ -101,6 +101,57 @@ func TestAccBackupResource_Compose(t *testing.T) {
 	})
 }
 
+func TestAccBackupResource_ComposePostgresService(t *testing.T) {
+	host := os.Getenv("DOKPLOY_HOST")
+	apiKey := os.Getenv("DOKPLOY_API_KEY")
+
+	if host == "" || apiKey == "" {
+		t.Skip("DOKPLOY_HOST and DOKPLOY_API_KEY must be set for acceptance tests")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBackupResourceConfig_ComposePostgresService(
+					"test-compose-pg-backup-project",
+					"test-compose-pg-backup-env",
+					"test-compose-pg-backup-dest",
+					"0 2 * * *",
+					true,
+					"compose-pg-backup",
+					"infisical",
+					"postgres",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dokploy_backup.test_compose_pg", "backup_type", "compose"),
+					resource.TestCheckResourceAttr("dokploy_backup.test_compose_pg", "database_type", "postgres"),
+					resource.TestCheckResourceAttr("dokploy_backup.test_compose_pg", "service_name", "postgres"),
+					resource.TestCheckResourceAttr("dokploy_backup.test_compose_pg", "database", "infisical"),
+				),
+			},
+			{
+				Config: testAccBackupResourceConfig_ComposePostgresService(
+					"test-compose-pg-backup-project",
+					"test-compose-pg-backup-env",
+					"test-compose-pg-backup-dest",
+					"0 3 * * *",
+					false,
+					"compose-pg-backup-updated",
+					"infisical",
+					"postgres",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dokploy_backup.test_compose_pg", "schedule", "0 3 * * *"),
+					resource.TestCheckResourceAttr("dokploy_backup.test_compose_pg", "enabled", "false"),
+					resource.TestCheckResourceAttr("dokploy_backup.test_compose_pg", "prefix", "compose-pg-backup-updated"),
+				),
+			},
+		},
+	})
+}
+
 func testAccBackupResourceConfig_Database(projectName, envName, dbName, appName, dbDbName, dbUser, destName, schedule string, enabled bool, prefix string) string {
 	return fmt.Sprintf(`
 provider "dokploy" {
@@ -204,6 +255,11 @@ resource "dokploy_backup" "test_compose" {
   backup_type       = "compose"
   service_name      = "db"
   database_type     = "postgres"
+  metadata = {
+    postgres = {
+      database_user = "postgres"
+    }
+  }
   schedule          = "%s"
   enabled           = %t
   prefix            = "%s"
@@ -211,4 +267,67 @@ resource "dokploy_backup" "test_compose" {
   keep_latest_count = 10
 }
 `, os.Getenv("DOKPLOY_HOST"), os.Getenv("DOKPLOY_API_KEY"), projectName, envName, destName, schedule, enabled, prefix)
+}
+
+func testAccBackupResourceConfig_ComposePostgresService(projectName, envName, destName, schedule string, enabled bool, prefix, databaseName, serviceName string) string {
+	return fmt.Sprintf(`
+provider "dokploy" {
+  host    = "%s"
+  api_key = "%s"
+}
+
+resource "dokploy_project" "test_compose_pg" {
+  name        = "%s"
+  description = "Test project for compose postgres backup metadata"
+}
+
+resource "dokploy_environment" "test_compose_pg" {
+  project_id = dokploy_project.test_compose_pg.id
+  name       = "%s"
+}
+
+resource "dokploy_compose" "test_compose_pg" {
+  name           = "test-compose-pg-backup"
+  environment_id = dokploy_environment.test_compose_pg.id
+  source_type    = "raw"
+  compose_file_content = <<-EOT
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: testpass123
+      POSTGRES_DB: %s
+      POSTGRES_USER: %s
+EOT
+}
+
+resource "dokploy_destination" "test_compose_pg" {
+  name              = "%s"
+  storage_provider  = "s3"
+  access_key        = "test-access-key"
+  secret_access_key = "test-secret-key"
+  bucket            = "test-compose-pg-backups"
+  region            = "us-east-1"
+  endpoint          = "https://s3.amazonaws.com"
+}
+
+resource "dokploy_backup" "test_compose_pg" {
+  destination_id    = dokploy_destination.test_compose_pg.id
+  compose_id        = dokploy_compose.test_compose_pg.id
+  backup_type       = "compose"
+  service_name      = "%s"
+  database_type     = "postgres"
+  metadata = {
+    postgres = {
+      database_user = "%s"
+    }
+  }
+  schedule          = "%s"
+  enabled           = %t
+  prefix            = "%s"
+  database          = "%s"
+  keep_latest_count = 7
+}
+`, os.Getenv("DOKPLOY_HOST"), os.Getenv("DOKPLOY_API_KEY"), projectName, envName, databaseName, databaseName, destName, serviceName, databaseName, schedule, enabled, prefix, databaseName)
 }


### PR DESCRIPTION
## Summary
- Add `metadata` nested block to `dokploy_backup` resource supporting postgres-specific backup fields.
- Fix `backup.update` payload missing required `metadata` for compose/postgres backups (causing 400 error).
- Add acceptance test for compose postgres backup flow.

## Changes
- `internal/client/client.go`: Extend Backup model with Metadata field
- `internal/provider/resource_backup.go`: Add metadata nested attribute + validation + payload mapping
- `internal/provider/resource_backup_test.go`: Update tests to use metadata block

## Validation
- Acceptance tests pass: `TestAccBackupResource_Compose`, `TestAccBackupResource_ComposePostgresService`

## Example usage
```hcl
resource "dokploy_backup" "example" {
  backup_type   = "compose"
  compose_id    = dokploy_compose.example.id
  service_name  = "postgres"
  database_type = "postgres"
  metadata = {
    postgres = {
      database_user = "mydbuser"
    }
  }
  # ... other fields
}
```