### PR TITLE
fix: application import and update against current Dokploy server

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1469,13 +1469,8 @@ func (c *DokployClient) SaveEnvironment(input SaveEnvironmentInput) error {
 
 	// env can be empty string, so we always include it
 	payload["env"] = input.Env
-
-	if input.BuildArgs != "" {
-		payload["buildArgs"] = input.BuildArgs
-	}
-	if input.BuildSecrets != "" {
-		payload["buildSecrets"] = input.BuildSecrets
-	}
+	payload["buildArgs"] = input.BuildArgs
+	payload["buildSecrets"] = input.BuildSecrets
 	if input.CreateEnvFile != nil {
 		payload["createEnvFile"] = *input.CreateEnvFile
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -730,8 +730,8 @@ type Application struct {
 	CustomGitSSHKeyId  string `json:"customGitSSHKeyId"`
 	CustomGitBuildPath string `json:"customGitBuildPath"`
 	EnableSubmodules   bool   `json:"enableSubmodules"`
-	WatchPaths         string `json:"watchPaths"` // Stored as JSON array string
-	CleanCache         bool   `json:"cleanCache"`
+	WatchPaths         []string `json:"watchPaths"`
+	CleanCache         bool     `json:"cleanCache"`
 
 	// GitHub provider settings (application.saveGithubProvider)
 	Repository  string `json:"repository"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1254,6 +1254,8 @@ func (c *DokployClient) SaveGithubProvider(input SaveGithubProviderInput) error 
 	}
 	if input.BuildPath != "" {
 		payload["buildPath"] = input.BuildPath
+	} else {
+		payload["buildPath"] = "/"
 	}
 	if len(input.WatchPaths) > 0 {
 		payload["watchPaths"] = input.WatchPaths

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1155,7 +1155,6 @@ func (c *DokployClient) ListApplicationsByEnvironment(environmentID string) ([]A
 // SaveBuildType configures the build type settings for an application.
 // Corresponds to application.saveBuildType endpoint.
 func (c *DokployClient) SaveBuildType(appID string, buildType string, dockerfile string, dockerContextPath string, dockerBuildStage string, publishDirectory string) error {
-	// The API requires all these fields to be present as strings (even if empty)
 	payload := map[string]interface{}{
 		"applicationId":     appID,
 		"buildType":         buildType,
@@ -1163,6 +1162,8 @@ func (c *DokployClient) SaveBuildType(appID string, buildType string, dockerfile
 		"dockerContextPath": dockerContextPath,
 		"dockerBuildStage":  dockerBuildStage,
 		"publishDirectory":  publishDirectory,
+		"herokuVersion":     "",
+		"railpackVersion":   "",
 	}
 
 	_, err := c.doRequest("POST", "application.saveBuildType", payload)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -15,6 +15,39 @@ import (
 // ErrNotFound is returned when a resource is not found (404).
 var ErrNotFound = errors.New("resource not found")
 
+// StringOrStringSlice unmarshals a JSON value that may be either a string
+// or an array of strings; arrays are joined with single spaces. Marshal
+// always emits a string.
+type StringOrStringSlice string
+
+func (s *StringOrStringSlice) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		*s = ""
+		return nil
+	}
+	if data[0] == '"' {
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		*s = StringOrStringSlice(str)
+		return nil
+	}
+	if data[0] == '[' {
+		var arr []string
+		if err := json.Unmarshal(data, &arr); err != nil {
+			return err
+		}
+		*s = StringOrStringSlice(strings.Join(arr, " "))
+		return nil
+	}
+	return fmt.Errorf("StringOrStringSlice: cannot decode %s", data)
+}
+
+func (s StringOrStringSlice) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(s))
+}
+
 // DokployClient holds connection details.
 type DokployClient struct {
 	BaseURL    string
@@ -797,9 +830,9 @@ type Application struct {
 	MemoryReservation json.Number `json:"memoryReservation"`
 	CpuLimit          json.Number `json:"cpuLimit"`
 	CpuReservation    json.Number `json:"cpuReservation"`
-	Command           string      `json:"command"`
-	Args              string      `json:"args"`
-	EntryPoint        string      `json:"entrypoint"`
+	Command           string              `json:"command"`
+	Args              StringOrStringSlice `json:"args"`
+	EntryPoint        string              `json:"entrypoint"`
 
 	// Docker Swarm configuration
 	HealthCheckSwarm     map[string]interface{}   `json:"healthCheckSwarm"`

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -1471,13 +1471,9 @@ func updatePlanFromApplication(plan *ApplicationResourceModel, app *client.Appli
 		}
 	}
 
-	// Parse WatchPaths from JSON string to types.List
-	if app.WatchPaths != "" {
-		var watchPaths []string
-		if err := json.Unmarshal([]byte(app.WatchPaths), &watchPaths); err == nil {
-			if listVal, diag := types.ListValueFrom(context.Background(), types.StringType, watchPaths); !diag.HasError() {
-				plan.WatchPaths = listVal
-			}
+	if len(app.WatchPaths) > 0 {
+		if listVal, diag := types.ListValueFrom(context.Background(), types.StringType, app.WatchPaths); !diag.HasError() {
+			plan.WatchPaths = listVal
 		}
 	}
 
@@ -1572,13 +1568,9 @@ func readApplicationIntoState(state *ApplicationResourceModel, app *client.Appli
 	}
 	state.EnableSubmodules = types.BoolValue(app.EnableSubmodules)
 	state.CleanCache = types.BoolValue(app.CleanCache)
-	// Parse WatchPaths from JSON string to types.List
-	if app.WatchPaths != "" {
-		var watchPaths []string
-		if err := json.Unmarshal([]byte(app.WatchPaths), &watchPaths); err == nil {
-			if listVal, diags := types.ListValueFrom(context.Background(), types.StringType, watchPaths); !diags.HasError() {
-				state.WatchPaths = listVal
-			}
+	if len(app.WatchPaths) > 0 {
+		if listVal, diags := types.ListValueFrom(context.Background(), types.StringType, app.WatchPaths); !diags.HasError() {
+			state.WatchPaths = listVal
 		}
 	}
 

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -999,7 +999,7 @@ func (r *ApplicationResource) updateGeneralSettings(appID string, plan *Applicat
 		generalApp.Command = plan.Command.ValueString()
 	}
 	if !plan.Args.IsNull() && !plan.Args.IsUnknown() {
-		generalApp.Args = plan.Args.ValueString()
+		generalApp.Args = client.StringOrStringSlice(plan.Args.ValueString())
 	}
 
 	// Preview deployments
@@ -1744,7 +1744,7 @@ func readApplicationIntoState(state *ApplicationResourceModel, app *client.Appli
 		state.Command = types.StringValue(app.Command)
 	}
 	if app.Args != "" {
-		state.Args = types.StringValue(app.Args)
+		state.Args = types.StringValue(string(app.Args))
 	}
 
 	// Preview deployments - always set computed fields


### PR DESCRIPTION
## Related Issue

Fixes # <!-- no prior issue; bugs surfaced during a fresh import + apply against current Dokploy v0.29.x. Happy to open one and reference it if preferred. -->

## Description

Five small fixes that together unblock `dokploy_application` import and apply against current Dokploy server releases. All in `internal/client/client.go` plus three small touches in `internal/provider/resource_application.go`. Each is a separate commit so they can be reviewed (or reverted) independently.

### 1. `Application.WatchPaths` decoded as `[]string`

The struct declared `WatchPaths string` with a comment saying Dokploy returned a stringified JSON array, but `application.one` actually returns a plain JSON array. Every Application Read failed at `json.Unmarshal`:

```
cannot unmarshal array into Go struct field Application.watchPaths of type string
```

Match the existing `Compose` struct's `[]string` typing. The two `resource_application.go` consumers that previously did `json.Unmarshal([]byte(app.WatchPaths), …)` now pass the slice straight to `types.ListValueFrom`, gated on `len > 0` to avoid a null↔[] flap that triggers `Provider produced inconsistent result after apply`.

**Repro:** `terraform import dokploy_application.foo <id>` against any github-sourced application — fails before, succeeds after.

### 2. `Application.Args` accepts string *or* array via `StringOrStringSlice`

Dokploy returns `args` as a string (e.g. `"celery -A worker"`) **or** as an array (e.g. `["-A","config","worker","-l","info"]`), depending on whether the user split command/args. The struct only handled the string form, so importing any application created with split args (very common for celery worker/beat) failed with the same `cannot unmarshal array` error.

Introduce a small `StringOrStringSlice` type with a permissive `UnmarshalJSON` that accepts either shape (joining arrays with single spaces) and a `MarshalJSON` that always emits a string. The existing `SaveGeneralApplicationInput.Args` write path keeps working unchanged.

```go
type StringOrStringSlice string

func (s *StringOrStringSlice) UnmarshalJSON(data []byte) error {
    // accepts "foo", ["a","b"], null, or "" — joins arrays with " "
}
```

The two `resource_application.go` consumers get cheap explicit conversions: `client.StringOrStringSlice(plan.Args.ValueString())` on the write side, `string(app.Args)` on the read side.

**Repro:** import a celery worker/beat application — fails before, succeeds after.

### 3. `saveBuildType` includes `herokuVersion` + `railpackVersion`

Recent Dokploy releases tightened the Zod schema for `application.saveBuildType` so both fields are `nonoptional`. The provider didn't send them, so every apply failed:

```
400 Bad Request: Invalid input: expected nonoptional, received undefined
paths: ["herokuVersion"], ["railpackVersion"]
```

Send both as empty strings — matches the UI's behaviour for an app that hasn't pinned a Heroku/Railpack version.

### 4. `saveGithubProvider` defaults `buildPath` to `"/"`

Same Zod tightening on `application.saveGithubProvider`: `buildPath` is now nonoptional. The provider only included it when non-empty, so any github-sourced application without a custom build path failed Update:

```
400 Bad Request: Invalid input: expected nonoptional, received undefined
path: ["buildPath"]
```

Default to `"/"` — what the UI writes for an app without a custom build path.

### 5. `saveEnvironment` always sends `buildArgs` + `buildSecrets`

Same pattern on `application.saveEnvironment`. Both fields became nonoptional; provider only sent them when non-empty. Empty string is accepted by the validator and is the natural default.

---

Tested end-to-end against Dokploy v0.29.x by running `terraform import` + `apply` for backend-api, frontend, and split-command celery apps; final plan reports `No changes`. All commits build cleanly and `go vet ./...` passes. No new tests added — the fixes touch the API client decoder + payload construction, both of which would benefit from tabletop tests but I didn't want to scope-creep this PR.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

The 5 commits are independent — any one can be reverted without breaking the others. Most likely target for revert: commit 2 (`StringOrStringSlice`) if a more idiomatic representation is preferred.

## Changes to Security Controls

None. All changes are bug fixes in the API client's request/response handling. No changes to authentication, authorization, encryption, or logging.