### PR TITLE
fix(client): always send buildArgs, buildSecrets, and createEnvFile in saveEnvironment

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1429,17 +1429,12 @@ type SaveEnvironmentInput struct {
 func (c *DokployClient) SaveEnvironment(input SaveEnvironmentInput) error {
 	payload := map[string]interface{}{
 		"applicationId": input.ApplicationID,
+		"env":           input.Env,
+		"buildArgs":     input.BuildArgs,
+		"buildSecrets":  input.BuildSecrets,
+		"createEnvFile": false,
 	}
 
-	// env can be empty string, so we always include it
-	payload["env"] = input.Env
-
-	if input.BuildArgs != "" {
-		payload["buildArgs"] = input.BuildArgs
-	}
-	if input.BuildSecrets != "" {
-		payload["buildSecrets"] = input.BuildSecrets
-	}
 	if input.CreateEnvFile != nil {
 		payload["createEnvFile"] = *input.CreateEnvFile
 	}
@@ -2574,6 +2569,9 @@ func (c *DokployClient) UpdateApplicationEnv(appID string, updateFn func(envMap 
 		payload := map[string]interface{}{
 			"applicationId": appID,
 			"env":           newEnvStr,
+			"buildArgs":     "",
+			"buildSecrets":  "",
+			"createEnvFile": false,
 		}
 		if createEnvFile != nil {
 			payload["createEnvFile"] = *createEnvFile


### PR DESCRIPTION
Fixes #40

Dokploy v0.28+ requires `buildArgs`, `buildSecrets`, and `createEnvFile` to be explicitly provided in the `application.saveEnvironment` payload.

Previously these fields were omitted when empty or nil, causing `BAD_REQUEST` errors when creating or updating environment settings for both `dokploy_application` and `dokploy_environment_variables` resources.

Changes:
- `SaveEnvironment`: always include `buildArgs`, `buildSecrets`, and a default `createEnvFile: false`
- `UpdateApplicationEnv`: always include empty `buildArgs` / `buildSecrets` and default `createEnvFile: false`

Tested against live Dokploy v0.28.6 instance.