### PR TITLE
fix(database): read app_name from API response during import and read

### DIFF
--- a/internal/provider/resource_mariadb.go
+++ b/internal/provider/resource_mariadb.go
@@ -356,6 +356,7 @@ func (r *MariaDBResource) ImportState(ctx context.Context, req resource.ImportSt
 func (r *MariaDBResource) mapMariaDBToState(state *MariaDBResourceModel, mariadb *client.MariaDB) {
 	state.ID = types.StringValue(mariadb.MariaDBID)
 	state.Name = types.StringValue(mariadb.Name)
+	state.AppName = types.StringValue(mariadb.AppName)
 	state.EnvironmentID = types.StringValue(mariadb.EnvironmentID)
 	state.ApplicationStatus = types.StringValue(mariadb.ApplicationStatus)
 	state.DatabaseName = types.StringValue(mariadb.DatabaseName)

--- a/internal/provider/resource_mongo.go
+++ b/internal/provider/resource_mongo.go
@@ -349,6 +349,7 @@ func (r *MongoDBResource) ImportState(ctx context.Context, req resource.ImportSt
 func (r *MongoDBResource) mapMongoDBToState(state *MongoDBResourceModel, mongo *client.MongoDB) {
 	state.ID = types.StringValue(mongo.MongoID)
 	state.Name = types.StringValue(mongo.Name)
+	state.AppName = types.StringValue(mongo.AppName)
 	state.EnvironmentID = types.StringValue(mongo.EnvironmentID)
 	state.ApplicationStatus = types.StringValue(mongo.ApplicationStatus)
 	state.DatabaseUser = types.StringValue(mongo.DatabaseUser)

--- a/internal/provider/resource_mysql.go
+++ b/internal/provider/resource_mysql.go
@@ -356,6 +356,7 @@ func (r *MySQLResource) ImportState(ctx context.Context, req resource.ImportStat
 func (r *MySQLResource) mapMySQLToState(state *MySQLResourceModel, mysql *client.MySQL) {
 	state.ID = types.StringValue(mysql.MySQLID)
 	state.Name = types.StringValue(mysql.Name)
+	state.AppName = types.StringValue(mysql.AppName)
 	state.EnvironmentID = types.StringValue(mysql.EnvironmentID)
 	state.ApplicationStatus = types.StringValue(mysql.ApplicationStatus)
 	state.DatabaseName = types.StringValue(mysql.DatabaseName)

--- a/internal/provider/resource_postgres.go
+++ b/internal/provider/resource_postgres.go
@@ -348,6 +348,7 @@ func (r *PostgresResource) ImportState(ctx context.Context, req resource.ImportS
 func (r *PostgresResource) mapPostgresToState(state *PostgresResourceModel, postgres *client.Postgres) {
 	state.ID = types.StringValue(postgres.PostgresID)
 	state.Name = types.StringValue(postgres.Name)
+	state.AppName = types.StringValue(postgres.AppName)
 	state.EnvironmentID = types.StringValue(postgres.EnvironmentID)
 	state.ApplicationStatus = types.StringValue(postgres.ApplicationStatus)
 	state.DatabaseName = types.StringValue(postgres.DatabaseName)


### PR DESCRIPTION
Fixes #39

The `map*ToState` functions for PostgreSQL, MySQL, MongoDB, and MariaDB were not populating `app_name` from the API response. This caused imports to leave `app_name` as null because there was no existing state to preserve.

The existing 'preserve from state' logic in Read() still works correctly for normal refresh cycles: when `state.AppName` is non-null, it overwrites the API value. During import, `state.AppName` is null, so the API value is now preserved.

Redis was already handling this correctly.

Tested against live Dokploy instance by verifying `GetPostgres` returns a non-empty `AppName`.