### PR TITLE
feat(backup): add metadata support to dokploy_backup resource

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -3590,22 +3590,23 @@ func (c *DokployClient) ListDestinations() ([]Destination, error) {
 
 // Backup represents a scheduled backup configuration.
 type Backup struct {
-	BackupID        string `json:"backupId"`
-	AppName         string `json:"appName"`
-	Schedule        string `json:"schedule"`
-	Enabled         bool   `json:"enabled"`
-	Database        string `json:"database"`
-	Prefix          string `json:"prefix"`
-	DestinationID   string `json:"destinationId"`
-	KeepLatestCount int    `json:"keepLatestCount"`
-	BackupType      string `json:"backupType"`   // "database" or "compose"
-	DatabaseType    string `json:"databaseType"` // "postgres", "mysql", "mariadb", "mongo"
-	PostgresID      string `json:"postgresId"`
-	MysqlID         string `json:"mysqlId"`
-	MariadbID       string `json:"mariadbId"`
-	MongoID         string `json:"mongoId"`
-	ComposeID       string `json:"composeId"`
-	ServiceName     string `json:"serviceName"`
+	BackupID        string            `json:"backupId"`
+	AppName         string            `json:"appName"`
+	Schedule        string            `json:"schedule"`
+	Enabled         bool              `json:"enabled"`
+	Database        string            `json:"database"`
+	Prefix          string            `json:"prefix"`
+	DestinationID   string            `json:"destinationId"`
+	KeepLatestCount int               `json:"keepLatestCount"`
+	BackupType      string            `json:"backupType"`   // "database" or "compose"
+	DatabaseType    string            `json:"databaseType"` // "postgres", "mysql", "mariadb", "mongo"
+	PostgresID      string            `json:"postgresId"`
+	MysqlID         string            `json:"mysqlId"`
+	MariadbID       string            `json:"mariadbId"`
+	MongoID         string            `json:"mongoId"`
+	ComposeID       string            `json:"composeId"`
+	ServiceName     string            `json:"serviceName"`
+	Metadata        map[string]string `json:"metadata,omitempty"`
 }
 
 func (c *DokployClient) CreateBackup(backup Backup) (*Backup, error) {
@@ -3641,6 +3642,9 @@ func (c *DokployClient) CreateBackup(backup Backup) (*Backup, error) {
 	}
 	if backup.ServiceName != "" {
 		payload["serviceName"] = backup.ServiceName
+	}
+	if len(backup.Metadata) > 0 {
+		payload["metadata"] = backup.Metadata
 	}
 
 	resp, err := c.doRequest("POST", "backup.create", payload)
@@ -3733,6 +3737,9 @@ func (c *DokployClient) UpdateBackup(backup Backup) (*Backup, error) {
 
 	if backup.KeepLatestCount > 0 {
 		payload["keepLatestCount"] = backup.KeepLatestCount
+	}
+	if len(backup.Metadata) > 0 {
+		payload["metadata"] = backup.Metadata
 	}
 
 	resp, err := c.doRequest("POST", "backup.update", payload)

--- a/internal/provider/resource_backup.go
+++ b/internal/provider/resource_backup.go
@@ -43,6 +43,7 @@ type BackupResourceModel struct {
 	Prefix          types.String `tfsdk:"prefix"`
 	Database        types.String `tfsdk:"database"`
 	KeepLatestCount types.Int64  `tfsdk:"keep_latest_count"`
+	Metadata        types.Map    `tfsdk:"metadata"`
 }
 
 func (r *BackupResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -128,6 +129,11 @@ func (r *BackupResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Default:     int64default.StaticInt64(30),
 				Description: "Number of recent backups to keep (older ones are deleted).",
 			},
+			"metadata": schema.MapAttribute{
+				Optional:    true,
+				ElementType: types.StringType,
+				Description: "Metadata for the backup configuration as key-value pairs.",
+			},
 		},
 	}
 }
@@ -187,6 +193,17 @@ func (r *BackupResource) Create(ctx context.Context, req resource.CreateRequest,
 		Database:        plan.Database.ValueString(),
 		KeepLatestCount: int(plan.KeepLatestCount.ValueInt64()),
 		BackupType:      backupType,
+	}
+
+	// Set metadata if provided
+	if !plan.Metadata.IsNull() && !plan.Metadata.IsUnknown() {
+		metadataMap := make(map[string]string)
+		diags = plan.Metadata.ElementsAs(ctx, &metadataMap, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		backup.Metadata = metadataMap
 	}
 
 	switch backupType {
@@ -287,6 +304,14 @@ func (r *BackupResource) Read(ctx context.Context, req resource.ReadRequest, res
 		}
 	}
 
+	// Read metadata if present
+	if backup.Metadata != nil && len(backup.Metadata) > 0 {
+		state.Metadata, diags = types.MapValueFrom(ctx, types.StringType, backup.Metadata)
+		resp.Diagnostics.Append(diags...)
+	} else {
+		state.Metadata = types.MapNull(types.StringType)
+	}
+
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 }
@@ -312,6 +337,17 @@ func (r *BackupResource) Update(ctx context.Context, req resource.UpdateRequest,
 		Prefix:          plan.Prefix.ValueString(),
 		Database:        plan.Database.ValueString(),
 		KeepLatestCount: int(plan.KeepLatestCount.ValueInt64()),
+	}
+
+	// Set metadata if provided
+	if !plan.Metadata.IsNull() && !plan.Metadata.IsUnknown() {
+		metadataMap := make(map[string]string)
+		diags = plan.Metadata.ElementsAs(ctx, &metadataMap, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		backup.Metadata = metadataMap
 	}
 
 	// Set database type for the update API


### PR DESCRIPTION
Fixes #30

Add a new `metadata` attribute to the `dokploy_backup` resource as a map of string key-value pairs. This maps to the Dokploy API's `metadata` field which accepts a JSON object for backup configuration.

Changes:
- `client.Backup`: add `Metadata map[string]string` field
- `CreateBackup` / `UpdateBackup`: include metadata in payload when set
- `BackupResourceModel`: add `Metadata types.Map` field
- Schema: add `metadata` as optional `MapAttribute` with `StringType` elements
- `Create` / `Read` / `Update`: handle metadata conversion between Terraform state and API

Tested against live Dokploy v0.28.6:
- Backup created with `metadata = {foo = "bar", key = "value"}` succeeds
- Reading the backup back returns the same metadata map