### PR TITLE
fix(compose): send env during create/update, mark as sensitive, avoid API-masked drift

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1918,7 +1918,7 @@ func (c *DokployClient) DeleteCompose(id string) error {
 	payload := map[string]string{
 		"composeId": id,
 	}
-	_, err := c.doRequest("POST", "compose.remove", payload)
+	_, err := c.doRequest("POST", "compose.delete", payload)
 	return err
 }
 

--- a/internal/provider/data_source_compose.go
+++ b/internal/provider/data_source_compose.go
@@ -267,6 +267,7 @@ func (d *ComposeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest
 			// Environment
 			"env": schema.StringAttribute{
 				Computed:    true,
+				Sensitive:   true,
 				Description: "Environment variables in KEY=VALUE format.",
 			},
 

--- a/internal/provider/resource_compose.go
+++ b/internal/provider/resource_compose.go
@@ -331,7 +331,11 @@ func (r *ComposeResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			// Environment
 			"env": schema.StringAttribute{
 				Optional:    true,
+				Sensitive:   true,
 				Description: "Environment variables in KEY=VALUE format, one per line.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 
 			// Runtime configuration
@@ -446,6 +450,7 @@ func (r *ComposeResource) Create(ctx context.Context, req resource.CreateRequest
 		Name:              plan.Name.ValueString(),
 		EnvironmentID:     plan.EnvironmentID.ValueString(),
 		ComposeFile:       plan.ComposeFileContent.ValueString(),
+		Env:               plan.Env.ValueString(),
 		SourceType:        plan.SourceType.ValueString(),
 		CustomGitUrl:      plan.CustomGitUrl.ValueString(),
 		CustomGitBranch:   plan.CustomGitBranch.ValueString(),
@@ -596,6 +601,13 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 
 	environmentChanged := !plan.EnvironmentID.Equal(state.EnvironmentID)
 
+	// Preserve existing env value when plan value is unknown.
+	// This can happen with sensitive values during apply.
+	effectiveEnv := plan.Env
+	if plan.Env.IsUnknown() {
+		effectiveEnv = state.Env
+	}
+
 	// Check if environment_id changed - use compose.move API
 	if environmentChanged {
 		movedComp, err := r.client.MoveCompose(plan.ID.ValueString(), plan.EnvironmentID.ValueString())
@@ -607,6 +619,7 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 		// Check if only environment_id changed - if so, skip the update call
 		onlyEnvironmentChanged := plan.Name.Equal(state.Name) &&
 			plan.ComposeFileContent.Equal(state.ComposeFileContent) &&
+			plan.Env.Equal(state.Env) &&
 			plan.SourceType.Equal(state.SourceType) &&
 			plan.CustomGitUrl.Equal(state.CustomGitUrl) &&
 			plan.CustomGitBranch.Equal(state.CustomGitBranch) &&
@@ -624,6 +637,7 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 		if onlyEnvironmentChanged {
 			// MoveCompose is sufficient; use returned data to update state
 			readComposeIntoState(ctx, &plan, movedComp, &resp.Diagnostics)
+			plan.Env = effectiveEnv
 			diags = resp.State.Set(ctx, plan)
 			resp.Diagnostics.Append(diags...)
 			return
@@ -645,6 +659,7 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 		Name:              plan.Name.ValueString(),
 		EnvironmentID:     plan.EnvironmentID.ValueString(),
 		ComposeFile:       plan.ComposeFileContent.ValueString(),
+		Env:               effectiveEnv.ValueString(),
 		SourceType:        plan.SourceType.ValueString(),
 		CustomGitUrl:      plan.CustomGitUrl.ValueString(),
 		CustomGitBranch:   plan.CustomGitBranch.ValueString(),
@@ -730,6 +745,7 @@ func (r *ComposeResource) Update(ctx context.Context, req resource.UpdateRequest
 	}
 
 	readComposeIntoState(ctx, &plan, updatedComp, &resp.Diagnostics)
+	plan.Env = effectiveEnv
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -911,8 +927,11 @@ func readComposeIntoState(ctx context.Context, state *ComposeResourceModel, comp
 		state.GiteaBuildPath = types.StringValue(comp.GiteaBuildPath)
 	}
 
-	// Environment
-	if comp.Env != "" {
+	// Environment - Do NOT read from API.
+	// The compose.one endpoint may return masked values for env,
+	// which would cause a perpetual diff. We keep the planned/config
+	// value in state instead (env is marked as sensitive).
+	if state.Env.IsUnknown() && comp.Env != "" {
 		state.Env = types.StringValue(comp.Env)
 	}
 


### PR DESCRIPTION
Re-implements the compose env fixes from #42 on current main.

## Problem

The compose resource was not sending `env` to the API during create or update because the `Env` field was never set on the `client.Compose` struct. This meant environment variables were silently ignored.

Additionally, the Dokploy API can mask or alter env values on read, causing "Provider produced inconsistent result after apply" errors when the returned value differed from what was sent.

## Changes

1. **Schema**: Mark `env` as `Sensitive` in both resource and data source, add `UseStateForUnknown` plan modifier
2. **Create**: Actually send `Env` in the create payload
3. **Update**: Actually send `Env` in the update payload, preserve state env when plan is unknown
4. **State mapping**: Do NOT unconditionally overwrite `state.Env` from the API response (only set if state is unknown)
5. **Move check**: Include `env` in the `onlyEnvironmentChanged` check so env-only updates are not skipped after `compose.move`
6. **Delete endpoint**: Change from `compose.remove` to `compose.delete` to match current Dokploy API

## Testing

Tested live against Dokploy v0.28.6:
- Create compose with env → env is persisted
- Read compose → API returns correct env
- Update compose with new env → env is updated
- Delete compose → `compose.delete` endpoint works correctly