### PR TITLE
fix(client): remaining application import/update fixes (4 of 5 from #46)

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1159,7 +1159,10 @@ func (c *DokployClient) ListApplicationsByEnvironment(environmentID string) ([]A
 // SaveBuildType configures the build type settings for an application.
 // Corresponds to application.saveBuildType endpoint.
 func (c *DokployClient) SaveBuildType(appID string, buildType string, dockerfile string, dockerContextPath string, dockerBuildStage string, publishDirectory string) error {
-	// The API requires all these fields to be present as strings (even if empty)
+	// The API requires all these fields to be present as strings (even if
+	// empty). Recent Dokploy releases tightened the Zod schema so
+	// herokuVersion and railpackVersion are nonoptional; send them as empty
+	// strings (the UI's default for an app that hasn't pinned a version).
 	payload := map[string]interface{}{
 		"applicationId":     appID,
 		"buildType":         buildType,
@@ -1167,6 +1170,8 @@ func (c *DokployClient) SaveBuildType(appID string, buildType string, dockerfile
 		"dockerContextPath": dockerContextPath,
 		"dockerBuildStage":  dockerBuildStage,
 		"publishDirectory":  publishDirectory,
+		"herokuVersion":     "",
+		"railpackVersion":   "",
 	}
 
 	_, err := c.doRequest("POST", "application.saveBuildType", payload)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -730,8 +730,8 @@ type Application struct {
 	CustomGitSSHKeyId  string `json:"customGitSSHKeyId"`
 	CustomGitBuildPath string `json:"customGitBuildPath"`
 	EnableSubmodules   bool   `json:"enableSubmodules"`
-	WatchPaths         string `json:"watchPaths"` // Stored as JSON array string
-	CleanCache         bool   `json:"cleanCache"`
+	WatchPaths         []string `json:"watchPaths"`
+	CleanCache         bool     `json:"cleanCache"`
 
 	// GitHub provider settings (application.saveGithubProvider)
 	Repository  string `json:"repository"`

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1260,8 +1260,13 @@ func (c *DokployClient) SaveGithubProvider(input SaveGithubProviderInput) error 
 	if input.Branch != "" {
 		payload["branch"] = input.Branch
 	}
+	// buildPath is nonoptional in recent Dokploy Zod schemas, so always
+	// include it. Default to "/" when unset -- matches the UI's behaviour
+	// for an app without a custom build path.
 	if input.BuildPath != "" {
 		payload["buildPath"] = input.BuildPath
+	} else {
+		payload["buildPath"] = "/"
 	}
 	if len(input.WatchPaths) > 0 {
 		payload["watchPaths"] = input.WatchPaths

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -711,6 +711,43 @@ func (c *DokployClient) DeleteEnvironment(id string) error {
 
 // --- Application ---
 
+// StringOrStringSlice round-trips a value that Dokploy may return as either a
+// JSON string or a JSON array of strings. Dokploy's application.one returns
+// `args` as a string when the user wrote a single command line, but as an
+// array when they split command/args (common for celery worker/beat). The
+// provider only ever needs to write a single string back, so MarshalJSON
+// always emits a string; UnmarshalJSON tolerates both shapes (joining array
+// elements with single spaces) plus null and the empty string.
+type StringOrStringSlice string
+
+func (s *StringOrStringSlice) UnmarshalJSON(data []byte) error {
+	if len(data) == 0 || string(data) == "null" {
+		*s = ""
+		return nil
+	}
+	if data[0] == '"' {
+		var str string
+		if err := json.Unmarshal(data, &str); err != nil {
+			return err
+		}
+		*s = StringOrStringSlice(str)
+		return nil
+	}
+	if data[0] == '[' {
+		var parts []string
+		if err := json.Unmarshal(data, &parts); err != nil {
+			return err
+		}
+		*s = StringOrStringSlice(strings.Join(parts, " "))
+		return nil
+	}
+	return fmt.Errorf("StringOrStringSlice: unexpected JSON token %q", string(data))
+}
+
+func (s StringOrStringSlice) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(s))
+}
+
 type Application struct {
 	// Core identifiers
 	ID            string `json:"applicationId"`
@@ -797,9 +834,9 @@ type Application struct {
 	MemoryReservation json.Number `json:"memoryReservation"`
 	CpuLimit          json.Number `json:"cpuLimit"`
 	CpuReservation    json.Number `json:"cpuReservation"`
-	Command           string      `json:"command"`
-	Args              string      `json:"args"`
-	EntryPoint        string      `json:"entrypoint"`
+	Command           string              `json:"command"`
+	Args              StringOrStringSlice `json:"args"`
+	EntryPoint        string              `json:"entrypoint"`
 
 	// Docker Swarm configuration
 	HealthCheckSwarm     map[string]interface{}   `json:"healthCheckSwarm"`

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -999,7 +999,7 @@ func (r *ApplicationResource) updateGeneralSettings(appID string, plan *Applicat
 		generalApp.Command = plan.Command.ValueString()
 	}
 	if !plan.Args.IsNull() && !plan.Args.IsUnknown() {
-		generalApp.Args = plan.Args.ValueString()
+		generalApp.Args = client.StringOrStringSlice(plan.Args.ValueString())
 	}
 
 	// Preview deployments
@@ -1750,7 +1750,7 @@ func readApplicationIntoState(state *ApplicationResourceModel, app *client.Appli
 		state.Command = types.StringValue(app.Command)
 	}
 	if app.Args != "" {
-		state.Args = types.StringValue(app.Args)
+		state.Args = types.StringValue(string(app.Args))
 	}
 
 	// Preview deployments - always set computed fields

--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -1471,13 +1471,12 @@ func updatePlanFromApplication(plan *ApplicationResourceModel, app *client.Appli
 		}
 	}
 
-	// Parse WatchPaths from JSON string to types.List
-	if app.WatchPaths != "" {
-		var watchPaths []string
-		if err := json.Unmarshal([]byte(app.WatchPaths), &watchPaths); err == nil {
-			if listVal, diag := types.ListValueFrom(context.Background(), types.StringType, watchPaths); !diag.HasError() {
-				plan.WatchPaths = listVal
-			}
+	// Populate WatchPaths from the API response. Guard on len > 0 so that an
+	// empty array doesn't flap state from null to [] (which would surface as
+	// "Provider produced inconsistent result after apply").
+	if len(app.WatchPaths) > 0 {
+		if listVal, diag := types.ListValueFrom(context.Background(), types.StringType, app.WatchPaths); !diag.HasError() {
+			plan.WatchPaths = listVal
 		}
 	}
 
@@ -1572,13 +1571,12 @@ func readApplicationIntoState(state *ApplicationResourceModel, app *client.Appli
 	}
 	state.EnableSubmodules = types.BoolValue(app.EnableSubmodules)
 	state.CleanCache = types.BoolValue(app.CleanCache)
-	// Parse WatchPaths from JSON string to types.List
-	if app.WatchPaths != "" {
-		var watchPaths []string
-		if err := json.Unmarshal([]byte(app.WatchPaths), &watchPaths); err == nil {
-			if listVal, diags := types.ListValueFrom(context.Background(), types.StringType, watchPaths); !diags.HasError() {
-				state.WatchPaths = listVal
-			}
+	// Populate WatchPaths from the API response. Guard on len > 0 so that an
+	// empty array doesn't flap state from null to [] (which would surface as
+	// "Provider produced inconsistent result after apply").
+	if len(app.WatchPaths) > 0 {
+		if listVal, diags := types.ListValueFrom(context.Background(), types.StringType, app.WatchPaths); !diags.HasError() {
+			state.WatchPaths = listVal
 		}
 	}
 


### PR DESCRIPTION
## Context

Refiles the four fixes from closed PR #46 that were not picked up by #47.

#46 bundled five fixes; the maintainer adopted only fix #5 (`saveEnvironment`) into #47 (merged), citing a more complete solution that also covers `UpdateApplicationEnv` and `createEnvFile`. Thank you for that.

The other four fixes were not addressed and `dokploy_application` import + apply against current Dokploy releases (v0.28+ / v0.29.x) still fails on every github-sourced application. This PR carries them forward, rebased onto current `main`, each as its own commit so they can be reviewed/reverted independently. Each commit has been re-derived against current `main` (not cherry-picked) so the diffs apply cleanly to the post-#47/#51 codebase.

## Fixes included

### 1. `Application.WatchPaths` decoded as `[]string`

The struct declared `WatchPaths string` with a comment claiming Dokploy returned a stringified JSON array, but `application.one` actually returns a plain JSON array. Every Application Read failed at `json.Unmarshal`:

    cannot unmarshal array into Go struct field Application.watchPaths of type string

Match the existing `Compose.WatchPaths` typing. Two `resource_application.go` consumers updated; null↔[] flap guarded with a `len > 0` check to avoid "Provider produced inconsistent result after apply".

**Repro:** `terraform import dokploy_application.foo <id>` against any github-sourced application — fails before, succeeds after.

### 2. `Application.Args` accepts string *or* array via `StringOrStringSlice`

Dokploy returns `args` as either `"celery -A worker"` or `["-A","config","worker","-l","info"]` depending on whether the user split command/args. Importing any application created with split args (very common for celery worker/beat) failed:

    cannot unmarshal array into Go struct field Application.args of type string

Adds a permissive `StringOrStringSlice` (UnmarshalJSON accepts either shape, plus null and empty string; MarshalJSON always emits a string), so existing write paths keep working unchanged.

**Repro:** import a celery worker/beat application — fails before, succeeds after.

### 3. `saveBuildType` includes `herokuVersion` + `railpackVersion`

Recent Dokploy releases tightened the `application.saveBuildType` Zod schema so both fields are `nonoptional`. The provider didn't send them; every apply failed:

    400 Bad Request: Invalid input: expected nonoptional, received undefined
    paths: ["herokuVersion"], ["railpackVersion"]

Send both as empty strings — matches the UI's behaviour for an app without a pinned version.

### 4. `saveGithubProvider` defaults `buildPath` to `"/"`

Same Zod tightening on `application.saveGithubProvider`: `buildPath` is now nonoptional. Provider only included it when non-empty, so any github-sourced application without a custom build path failed Update:

    400 Bad Request: Invalid input: expected nonoptional, received undefined
    path: ["buildPath"]

Default to `"/"` — what the UI writes for an app without a custom build path.

## Testing

Tested end-to-end against Dokploy v0.29.x: `import` + `apply` for backend-api, frontend, and split-command celery applications; final `terraform plan` returns "No changes". `go build ./...` and `go vet ./...` pass on every commit.

## Rollback

The four commits are independent — any one can be reverted without breaking the others.

## Related

- Closed: #46 (the original five-fix bundle this PR completes)
- Merged: #47 (fix #5 of #46 — `saveEnvironment`)
- Merged: #51 (compose env+description drop — separate workaround, unrelated to this PR)
