### PR TITLE
correctly handle watch_paths for application resources

### DIFF
--- a/internal/provider/resource_application.go
+++ b/internal/provider/resource_application.go
@@ -8,11 +8,13 @@ import (
 
 	"github.com/ahmedali6/terraform-provider-dokploy/internal/client"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -256,8 +258,10 @@ func (r *ApplicationResource) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 			"watch_paths": schema.ListAttribute{
 				Optional:    true,
+				Computed:    true,
 				ElementType: types.StringType,
 				Description: "Paths to watch for changes to trigger deployments.",
+				Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
 			},
 
 			// GitHub provider settings (source_type = "github")
@@ -1144,6 +1148,15 @@ func (r *ApplicationResource) saveBuildType(appID string, plan *ApplicationResou
 func (r *ApplicationResource) saveSourceProvider(appID string, plan *ApplicationResourceModel) error {
 	sourceType := plan.SourceType.ValueString()
 
+	var watchPaths []string
+	if !plan.WatchPaths.IsNull() && !plan.WatchPaths.IsUnknown() {
+		for _, v := range plan.WatchPaths.Elements() {
+			if s, ok := v.(types.String); ok {
+				watchPaths = append(watchPaths, s.ValueString())
+			}
+		}
+	}
+
 	switch sourceType {
 	case "github":
 		// Use github_* fields if set, otherwise fall back to legacy fields for backward compatibility
@@ -1172,6 +1185,7 @@ func (r *ApplicationResource) saveSourceProvider(appID string, plan *Application
 			GithubId:         plan.GithubId.ValueString(),
 			EnableSubmodules: plan.EnableSubmodules.ValueBool(),
 			TriggerType:      plan.TriggerType.ValueString(),
+			WatchPaths:       watchPaths,
 		}
 		return r.client.SaveGithubProvider(input)
 
@@ -1186,6 +1200,7 @@ func (r *ApplicationResource) saveSourceProvider(appID string, plan *Application
 			GitlabBuildPath:     plan.GitlabBuildPath.ValueString(),
 			GitlabPathNamespace: plan.GitlabPathNamespace.ValueString(),
 			EnableSubmodules:    plan.EnableSubmodules.ValueBool(),
+			WatchPaths:          watchPaths,
 		}
 		return r.client.SaveGitlabProvider(input)
 
@@ -1198,6 +1213,7 @@ func (r *ApplicationResource) saveSourceProvider(appID string, plan *Application
 			BitbucketBranch:     plan.BitbucketBranch.ValueString(),
 			BitbucketBuildPath:  plan.BitbucketBuildPath.ValueString(),
 			EnableSubmodules:    plan.EnableSubmodules.ValueBool(),
+			WatchPaths:          watchPaths,
 		}
 		return r.client.SaveBitbucketProvider(input)
 
@@ -1210,6 +1226,7 @@ func (r *ApplicationResource) saveSourceProvider(appID string, plan *Application
 			GiteaBranch:      plan.GiteaBranch.ValueString(),
 			GiteaBuildPath:   plan.GiteaBuildPath.ValueString(),
 			EnableSubmodules: plan.EnableSubmodules.ValueBool(),
+			WatchPaths:       watchPaths,
 		}
 		return r.client.SaveGiteaProvider(input)
 
@@ -1221,6 +1238,7 @@ func (r *ApplicationResource) saveSourceProvider(appID string, plan *Application
 			CustomGitBuildPath: plan.CustomGitBuildPath.ValueString(),
 			CustomGitSSHKeyId:  plan.CustomGitSSHKeyID.ValueString(),
 			EnableSubmodules:   plan.EnableSubmodules.ValueBool(),
+			WatchPaths:         watchPaths,
 		}
 		return r.client.SaveGitProvider(input)
 

--- a/internal/provider/resource_application_test.go
+++ b/internal/provider/resource_application_test.go
@@ -79,6 +79,9 @@ func TestAccApplicationResourceWithGit(t *testing.T) {
 					resource.TestCheckResourceAttr("dokploy_application.test", "name", "test-git-app"),
 					resource.TestCheckResourceAttr("dokploy_application.test", "custom_git_url", "https://github.com/dokploy/dokploy"),
 					resource.TestCheckResourceAttr("dokploy_application.test", "custom_git_branch", "main"),
+					resource.TestCheckResourceAttr("dokploy_application.test", "watch_paths.#", "2"),
+					resource.TestCheckResourceAttr("dokploy_application.test", "watch_paths.0", "src/"),
+					resource.TestCheckResourceAttr("dokploy_application.test", "watch_paths.1", "package.json"),
 					resource.TestCheckResourceAttrSet("dokploy_application.test", "id"),
 				),
 			},
@@ -88,6 +91,9 @@ func TestAccApplicationResourceWithGit(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("dokploy_application.test", "name", "test-git-app-updated"),
 					resource.TestCheckResourceAttr("dokploy_application.test", "custom_git_branch", "canary"),
+					resource.TestCheckResourceAttr("dokploy_application.test", "watch_paths.#", "2"),
+					resource.TestCheckResourceAttr("dokploy_application.test", "watch_paths.0", "src/"),
+					resource.TestCheckResourceAttr("dokploy_application.test", "watch_paths.1", "package.json"),
 				),
 			},
 			// ImportState testing
@@ -157,6 +163,7 @@ resource "dokploy_application" "test" {
   build_type         = "nixpacks"
   custom_git_url     = "https://github.com/dokploy/dokploy"
   custom_git_branch  = "%s"
+  watch_paths        = ["src/", "package.json"]
 }
 `, os.Getenv("DOKPLOY_HOST"), os.Getenv("DOKPLOY_API_KEY"), projectName, envName, appName, branch)
 }


### PR DESCRIPTION
## Related Issue

Fixes #59

## Description

Attempting to create `dokploy_application` using `git*` provider with or without `watch_paths = []` fails with the following error:

```
│ API error: 400 Bad Request - {"message":"Input validation failed","code":"BAD_REQUEST","data":{"code":"BAD_REQUEST","httpStatus":400,"path":"application.saveGitProvider","zodError":{"formErrors":[],"fieldErrors":{"watchPaths":["Invalid input: expected nonoptional,
│ received undefined"]}}},"issues":[{"code":"invalid_type","expected":"nonoptional","path":["watchPaths"],"message":"Invalid input: expected nonoptional, received undefined"}]}
```

prettified:

```json
{
  "message": "Input validation failed",
  "code": "BAD_REQUEST",
  "data": {
    "code": "BAD_REQUEST",
    "httpStatus": 400,
    "path": "application.saveGitProvider",
    "zodError": {
      "formErrors": [],
      "fieldErrors": {
        "watchPaths": [
          "Invalid input: expected nonoptional, received undefined"
        ]
      }
    }
  },
  "issues": [
    {
      "code": "invalid_type",
      "expected": "nonoptional",
      "path": ["watchPaths"],
      "message": "Invalid input: expected nonoptional, received undefined"
    }
  ]
}
```

This is because `apiSaveGit*Provider` in https://github.com/Dokploy/dokploy/blob/6675aa6f37be52d5fd313ceb2e6f845dd4995643/apps/dokploy/server/api/routers/application.ts requires `watchPaths`.

but https://github.com/ahmedali6/terraform-provider-dokploy/blob/2c6bf85f7957a230f89e7a01ff9511a2085129c3/internal/provider/resource_application.go#L1144 does not include them.

To fix this, I've added the following code:

```go
	var watchPaths []string
	if !plan.WatchPaths.IsNull() && !plan.WatchPaths.IsUnknown() {
		for _, v := range plan.WatchPaths.Elements() {
			if s, ok := v.(types.String); ok {
				watchPaths = append(watchPaths, s.ValueString())
			}
		}
	}
```

so if `watch_paths` is not defined it uses empty array and the provided values when defined.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
