### PR TITLE
fix: adopt Dokploy's auto-created production environment on create

### DIFF
--- a/internal/provider/resource_environment.go
+++ b/internal/provider/resource_environment.go
@@ -84,8 +84,9 @@ func (r *EnvironmentResource) Create(ctx context.Context, req resource.CreateReq
 
 	env, err := r.client.CreateEnvironment(plan.ProjectID.ValueString(), plan.Name.ValueString(), plan.Description.ValueString())
 	if err != nil {
-		// Handle "Already exists" logic
-		if strings.Contains(strings.ToLower(err.Error()), "already exists") || strings.Contains(strings.ToLower(err.Error()), "duplicate") {
+		// Handle "already exists" / "duplicate" / reserved-name rejection by adopting
+		// the environment Dokploy already created.
+		if isAdoptableEnvironmentCreateError(err) {
 			// Fetch project to find the existing environment
 			project, pErr := r.client.GetProject(plan.ProjectID.ValueString())
 			if pErr != nil {
@@ -119,6 +120,25 @@ func (r *EnvironmentResource) Create(ctx context.Context, req resource.CreateReq
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
+}
+
+// isAdoptableEnvironmentCreateError reports whether a CreateEnvironment error
+// means the environment already exists server-side and should be adopted
+// (by looking it up on the parent project) rather than surfaced as a create
+// failure. This covers the generic "already exists"/"duplicate" API
+// responses, as well as Dokploy's reserved-name rejection: Dokploy
+// auto-creates a "production" environment for every new project, so an
+// explicit create of an environment named "production" always 400s with
+// "You cannot create a environment with the name 'production'" even though
+// no duplicate/already-exists wording is used.
+func isAdoptableEnvironmentCreateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	lower := strings.ToLower(err.Error())
+	return strings.Contains(lower, "already exists") ||
+		strings.Contains(lower, "duplicate") ||
+		strings.Contains(lower, "cannot create a environment with the name 'production'")
 }
 
 func (r *EnvironmentResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {

--- a/internal/provider/resource_environment_test.go
+++ b/internal/provider/resource_environment_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -8,6 +9,54 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+// TestIsAdoptableEnvironmentCreateError covers the Create error-recovery
+// matcher: Dokploy auto-creates a "production" environment for every new
+// project, so an explicit create of an environment named "production"
+// always fails with this reserved-name message (not "already exists" or
+// "duplicate"). Without this case, adoption never fires for the one
+// scenario that matters for a same-apply tenant onboarding.
+func TestIsAdoptableEnvironmentCreateError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "already exists",
+			err:  errors.New("environment already exists"),
+			want: true,
+		},
+		{
+			name: "duplicate",
+			err:  errors.New("duplicate environment name"),
+			want: true,
+		},
+		{
+			name: "reserved production name (mixed case, matches Dokploy's exact message)",
+			err:  errors.New("Bad Request: You cannot create a environment with the name 'production'"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("connection refused"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAdoptableEnvironmentCreateError(tt.err); got != tt.want {
+				t.Errorf("isAdoptableEnvironmentCreateError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestAccEnvironmentResource(t *testing.T) {
 	host := os.Getenv("DOKPLOY_HOST")


### PR DESCRIPTION
## Problem

Dokploy auto-creates a `production` environment for every new project, and its API rejects explicit creation of that name with HTTP 400:

```
You cannot create a environment with the name 'production'
```

(reserved-name guard in `apps/dokploy/server/api/routers/environment.ts`.)

`resource_environment.go` already has adopt-on-create recovery for this situation, but its matcher only checks for `already exists` / `duplicate`, so it never fires for the reserved-name message. Result: a fresh `dokploy_project` + `dokploy_environment { name = "production" }` cannot be applied in one run — and Terraform `import` blocks can't cover it either, since their `id` must be known at plan time. Users end up with a two-apply + manual-import workflow for every new project.

## Fix

- Extracts the recovery condition into `isAdoptableEnvironmentCreateError` and adds the reserved-name message to it (case-insensitive, same style as the existing checks).
- Adds a table-driven unit test covering nil / already-exists / duplicate / the exact Dokploy reserved-name message / unrelated errors.

With this, declaring `dokploy_environment` with `name = "production"` on a fresh project adopts the server's auto-created environment in the same apply, which is what the existing recovery clearly intended.

## Notes

- No schema or behavior change for any other path; non-production duplicate handling is untouched.
- Verified the server message against the current Dokploy source; the guard has been in place since environments were introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)